### PR TITLE
Fixes some bugs on WSL

### DIFF
--- a/lua/vocal/recording.lua
+++ b/lua/vocal/recording.lua
@@ -52,12 +52,13 @@ function M.start_recording(recording_dir, on_start, on_error)
     end,
     on_stderr = function(_, data)
       if data and #data > 0 and data[1] ~= "" then
-        local msg = table.concat(data, "\n")
+        local msg = type(data) == "table" and table.concat(data, "\n") or data
         if
           not msg:match("ALSA")
           and not msg:match("warning")
           and not msg:match("rate")
           and not msg:match("format")
+          and not msg:match("can't encode 0%-bit Unknown or not applicable")
         then
           api.debug_log("Recording stderr:", msg)
           if on_error then on_error(fmt("Recording error: %s", msg)) end


### PR DESCRIPTION
I ran into a couple errors running in nvim 0.11.1 under WSL:

* When stderr was a single line, `data` was a string rather than a table so `table.concat` failed.
  * Resolved by just checking the type.
* Seemingly harmless warnings about "can't encode 0-bit Unknown or not applicable" preventing transcription.
  * Added that message to the list of harmless error messages. (Technically searching for lower-case "alsa" would have worked as well, but I'm not confident that wouldn't also catch actual errors.)
* Errors about calling `nvim_win_is_valid` and `nvim_buf_is_valid` from "a fast event context".
  * Wrapped some of the UI logic in `vim.schedule` so it would run where it's allowed to.
